### PR TITLE
Fixing MIP and re-order MoFREAK descriptor

### DIFF
--- a/src/MoFREAK/MoFREAKUtilities.cpp
+++ b/src/MoFREAK/MoFREAKUtilities.cpp
@@ -76,10 +76,10 @@ unsigned int MoFREAKUtilities::motionInterchangePattern(cv::Mat &current_frame, 
 	for (auto it = previous_patches.begin(); it != previous_patches.end(); ++it)
 	{
 		int ssd = 0;
+        uchar *p = patch_t.data;
+        uchar *p2 = it->data;
 		for (int row = 0; row < 3; ++row)
 		{
-			uchar *p = patch_t.data;
-			uchar *p2 = it->data;
 			for (int col = 0; col < 3; ++col)
 			{
 				ssd += (int)pow((float)((*p) - (*p2)), 2);
@@ -450,18 +450,18 @@ void MoFREAKUtilities::computeMoFREAKFromFile(std::string video_filename, std::s
 				ftr.x = keypt->pt.x;
 				ftr.y = keypt->pt.y;
 
-				for (unsigned i = 0; i < NUMBER_OF_BYTES_FOR_MOTION; ++i)
+				for (unsigned i = 0; i < NUMBER_OF_BYTES_FOR_APPEARANCE; ++i)
 				{
-					ftr.motion[i] = pointer_to_descriptor_row[i];
+					ftr.appearance[i] = pointer_to_descriptor_row[i];
 				}
 
 				// MIP
 				vector<unsigned int> motion_desc;
 				extractMotionByMotionInterchangePatterns(current_frame, prev_frame, motion_desc, keypt->size, keypt->pt.x, keypt->pt.y);
 
-				for (unsigned i = 0; i < NUMBER_OF_BYTES_FOR_APPEARANCE; ++i)
+				for (unsigned i = 0; i < NUMBER_OF_BYTES_FOR_MOTION; ++i)
 				{
-					ftr.appearance[i] = motion_desc[i];
+					ftr.motion[i] = motion_desc[i];
 				}
 
 				// gather metadata.


### PR DESCRIPTION
Hi Whiten,
I'm Chung-Yu Chi, a master student studying at National Taiwan University GIEE. I'm very impressed by your work MoFREAK, and I'm doing some experiments and researches based on your work. During the research, I thought I may have found some small bugs and would like to discuss with you.

While calculating Motion Interchange Pattern, I thought the declaration of "p" and "p2" should be outside of the two "for" loops to make the calculation of SSD right. Is my thought correct?

On the other hand, in the MoFREAK descriptor, I thought "ftr.motion" nominally encode the motion part and "ftr.appearance" should encode the appearance part. So I swapped two recording parts. It's not a big problem because the modification won't effect any results. It just re-order the encoding of MoFREAK and make the code more reasonable.

Thank you and have a nice day!
